### PR TITLE
Adding url to progressCallback result

### DIFF
--- a/lib/httpreq.js
+++ b/lib/httpreq.js
@@ -333,6 +333,7 @@ function doRequest (o, callback) {
           currentsize += chunk.length;
 
           o.progressCallback (null, {
+            url: o.url,
             totalsize: totalsize,
             currentsize: currentsize,
             percentage: currentsize * 100 / totalsize


### PR DESCRIPTION
It's the only way to track multiple concurrent downloads.